### PR TITLE
Add recipe creation and persistence

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    id("org.jetbrains.kotlin.kapt")
 }
 
 android {
@@ -49,6 +50,11 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    kapt(libs.androidx.room.compiler)
+    implementation(libs.androidx.datastore.preferences)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/timer/MainActivity.kt
+++ b/app/src/main/java/com/example/timer/MainActivity.kt
@@ -4,13 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import com.example.timer.ui.theme.TimerTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,29 +12,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             TimerTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                TimerApp(this)
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    TimerTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/example/timer/NotificationUtils.kt
+++ b/app/src/main/java/com/example/timer/NotificationUtils.kt
@@ -1,0 +1,47 @@
+package com.example.timer
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.media.AudioAttributes
+import android.net.Uri
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.example.timer.prefs.PreferencesRepository
+import kotlinx.coroutines.flow.first
+
+suspend fun showFinishNotification(context: Context, prefs: PreferencesRepository) {
+    val soundUri = prefs.soundUri.first()?.let { Uri.parse(it) }
+    val vibrationEnabled = prefs.vibrationEnabled.first()
+    val channelId = "timer"
+    val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        val channel = NotificationChannel(channelId, "Timer", NotificationManager.IMPORTANCE_DEFAULT).apply {
+            if (soundUri != null) {
+                val attrs = AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                    .build()
+                setSound(soundUri, attrs)
+            }
+        }
+        manager.createNotificationChannel(channel)
+    }
+    val builder = NotificationCompat.Builder(context, channelId)
+        .setSmallIcon(android.R.drawable.ic_dialog_info)
+        .setContentTitle(context.getString(R.string.app_name))
+        .setContentText("Timer finished")
+        .setAutoCancel(true)
+    with(NotificationManagerCompat.from(context)) { notify(1, builder.build()) }
+    if (vibrationEnabled) {
+        val vibrator = context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            vibrator.vibrate(VibrationEffect.createOneShot(500, VibrationEffect.DEFAULT_AMPLITUDE))
+        } else {
+            @Suppress("DEPRECATION")
+            vibrator.vibrate(500)
+        }
+    }
+}

--- a/app/src/main/java/com/example/timer/TimerApp.kt
+++ b/app/src/main/java/com/example/timer/TimerApp.kt
@@ -1,0 +1,29 @@
+package com.example.timer
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.timer.data.RecipeDatabase
+import com.example.timer.data.RecipeRepository
+import com.example.timer.ui.recipe.EditRecipeScreen
+import com.example.timer.ui.recipe.RecipeListScreen
+import com.example.timer.prefs.PreferencesRepository
+import com.example.timer.ui.settings.SettingsScreen
+
+@Composable
+fun TimerApp(context: android.content.Context) {
+    val db = remember { RecipeDatabase.get(context) }
+    val repo = remember { RecipeRepository(db.recipeDao()) }
+    val prefs = remember { PreferencesRepository(context) }
+    val navController = rememberNavController()
+    NavHost(navController, startDestination = "list") {
+        composable("list") { RecipeListScreen(navController, repo) }
+        composable("edit/{id}") { backStackEntry ->
+            val id = backStackEntry.arguments?.getString("id")?.toIntOrNull() ?: 0
+            EditRecipeScreen(navController, repo, id)
+        }
+        composable("settings") { SettingsScreen(navController, prefs) }
+    }
+}

--- a/app/src/main/java/com/example/timer/data/Converters.kt
+++ b/app/src/main/java/com/example/timer/data/Converters.kt
@@ -1,0 +1,12 @@
+package com.example.timer.data
+
+import androidx.room.TypeConverter
+
+class Converters {
+    @TypeConverter
+    fun durationsToString(list: List<Long>): String = list.joinToString(",")
+
+    @TypeConverter
+    fun stringToDurations(value: String): List<Long> =
+        if (value.isBlank()) emptyList() else value.split(",").map { it.toLong() }
+}

--- a/app/src/main/java/com/example/timer/data/Recipe.kt
+++ b/app/src/main/java/com/example/timer/data/Recipe.kt
@@ -1,0 +1,11 @@
+package com.example.timer.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "recipes")
+data class Recipe(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val name: String,
+    val durations: List<Long>
+)

--- a/app/src/main/java/com/example/timer/data/RecipeDao.kt
+++ b/app/src/main/java/com/example/timer/data/RecipeDao.kt
@@ -1,0 +1,22 @@
+package com.example.timer.data
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface RecipeDao {
+    @Query("SELECT * FROM recipes")
+    fun getAll(): Flow<List<Recipe>>
+
+    @Query("SELECT * FROM recipes WHERE id = :id")
+    suspend fun getById(id: Int): Recipe?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(recipe: Recipe): Long
+
+    @Update
+    suspend fun update(recipe: Recipe)
+
+    @Delete
+    suspend fun delete(recipe: Recipe)
+}

--- a/app/src/main/java/com/example/timer/data/RecipeDatabase.kt
+++ b/app/src/main/java/com/example/timer/data/RecipeDatabase.kt
@@ -1,0 +1,27 @@
+package com.example.timer.data
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+
+@Database(entities = [Recipe::class], version = 1)
+@TypeConverters(Converters::class)
+abstract class RecipeDatabase : RoomDatabase() {
+    abstract fun recipeDao(): RecipeDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: RecipeDatabase? = null
+
+        fun get(context: Context): RecipeDatabase =
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    RecipeDatabase::class.java,
+                    "recipes.db"
+                ).build().also { INSTANCE = it }
+            }
+    }
+}

--- a/app/src/main/java/com/example/timer/data/RecipeRepository.kt
+++ b/app/src/main/java/com/example/timer/data/RecipeRepository.kt
@@ -1,0 +1,15 @@
+package com.example.timer.data
+
+import kotlinx.coroutines.flow.Flow
+
+class RecipeRepository(private val dao: RecipeDao) {
+    val recipes: Flow<List<Recipe>> = dao.getAll()
+
+    suspend fun get(id: Int): Recipe? = dao.getById(id)
+
+    suspend fun save(recipe: Recipe) {
+        if (recipe.id == 0) dao.insert(recipe) else dao.update(recipe)
+    }
+
+    suspend fun delete(recipe: Recipe) = dao.delete(recipe)
+}

--- a/app/src/main/java/com/example/timer/prefs/PreferencesRepository.kt
+++ b/app/src/main/java/com/example/timer/prefs/PreferencesRepository.kt
@@ -1,0 +1,30 @@
+package com.example.timer.prefs
+
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class PreferencesRepository(private val context: Context) {
+    private val Context.dataStore by preferencesDataStore("settings")
+
+    private val SOUND_KEY = stringPreferencesKey("sound_uri")
+    private val VIBRATION_KEY = booleanPreferencesKey("vibration")
+
+    val soundUri: Flow<String?> = context.dataStore.data.map { it[SOUND_KEY] }
+    val vibrationEnabled: Flow<Boolean> = context.dataStore.data.map { it[VIBRATION_KEY] ?: true }
+
+    suspend fun setSoundUri(uri: String?) {
+        context.dataStore.edit { prefs ->
+            if (uri != null) prefs[SOUND_KEY] = uri else prefs.remove(SOUND_KEY)
+        }
+    }
+
+    suspend fun setVibration(enabled: Boolean) {
+        context.dataStore.edit { it[VIBRATION_KEY] = enabled }
+    }
+}

--- a/app/src/main/java/com/example/timer/ui/recipe/EditRecipeScreen.kt
+++ b/app/src/main/java/com/example/timer/ui/recipe/EditRecipeScreen.kt
@@ -1,0 +1,59 @@
+package com.example.timer.ui.recipe
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.example.timer.data.Recipe
+import com.example.timer.data.RecipeRepository
+import kotlinx.coroutines.launch
+
+@Composable
+fun EditRecipeScreen(navController: NavController, repo: RecipeRepository, recipeId: Int) {
+    val scope = rememberCoroutineScope()
+    var name by remember { mutableStateOf("") }
+    var durations by remember { mutableStateOf("") }
+
+    LaunchedEffect(recipeId) {
+        if (recipeId != 0) {
+            repo.get(recipeId)?.let {
+                name = it.name
+                durations = it.durations.joinToString(",")
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(if (recipeId == 0) "New Recipe" else "Edit Recipe") })
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = {
+                val list = durations.split(',').mapNotNull { it.toLongOrNull() }
+                scope.launch {
+                    repo.save(Recipe(id = recipeId, name = name, durations = list))
+                    navController.popBackStack()
+                }
+            }) {
+                Text("OK")
+            }
+        }
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding).fillMaxSize()) {
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Name") },
+                modifier = Modifier.fillMaxWidth().padding(16.dp)
+            )
+            OutlinedTextField(
+                value = durations,
+                onValueChange = { durations = it },
+                label = { Text("Durations (sec, comma separated)") },
+                modifier = Modifier.fillMaxWidth().padding(16.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/timer/ui/recipe/RecipeListScreen.kt
+++ b/app/src/main/java/com/example/timer/ui/recipe/RecipeListScreen.kt
@@ -1,0 +1,55 @@
+package com.example.timer.ui.recipe
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.example.timer.data.RecipeRepository
+
+@Composable
+fun RecipeListScreen(navController: NavController, repo: RecipeRepository) {
+    val recipes = repo.recipes.collectAsState(initial = emptyList())
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Recipes") },
+                actions = {
+                    IconButton(onClick = { navController.navigate("settings") }) {
+                        Icon(Icons.Default.Settings, contentDescription = null)
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { navController.navigate("edit/0") }) {
+                Text("+")
+            }
+        }
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding).fillMaxSize()) {
+            recipes.value.forEach { recipe ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
+                    onClick = { navController.navigate("edit/${recipe.id}") }
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .padding(16.dp)
+                            .fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(recipe.name, style = MaterialTheme.typography.bodyLarge)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/timer/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/timer/ui/settings/SettingsScreen.kt
@@ -1,0 +1,41 @@
+package com.example.timer.ui.settings
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.example.timer.prefs.PreferencesRepository
+import kotlinx.coroutines.launch
+
+@Composable
+fun SettingsScreen(navController: NavController, prefs: PreferencesRepository) {
+    val scope = rememberCoroutineScope()
+    val soundUri by prefs.soundUri.collectAsState(initial = null)
+    val vibration by prefs.vibrationEnabled.collectAsState(initial = true)
+    var soundText by remember { mutableStateOf(soundUri ?: "") }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Settings") }) }
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding).padding(16.dp)) {
+            OutlinedTextField(
+                value = soundText,
+                onValueChange = { soundText = it },
+                label = { Text("Sound URI") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Checkbox(checked = vibration, onCheckedChange = {
+                    scope.launch { prefs.setVibration(it) }
+                })
+                Text("Vibration")
+            }
+            Button(onClick = {
+                scope.launch { prefs.setSoundUri(soundText.ifBlank { null }) }
+                navController.popBackStack()
+            }) { Text("Save") }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Timer</string>
+    <string name="timer_finished">Timer finished</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,9 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
+room = "2.6.1"
+navigationCompose = "2.7.7"
+datastore = "1.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,9 +27,15 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 


### PR DESCRIPTION
## Summary
- store recipes in Room database
- allow creating and editing recipes
- save sound URI and vibration preference using DataStore
- add settings screen
- wire up navigation via `TimerApp`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ff51b0d8833399c73e4c103bf625